### PR TITLE
Fixed bug with sphinx-build generating api.rst

### DIFF
--- a/despasito/main.py
+++ b/despasito/main.py
@@ -46,7 +46,7 @@ def commandline_parser():
     method_stat.disable_cython = not args.cython
     method_stat.disable_python = not args.python
 
-    return parser
+    return args
 
 def run(filename="input.json", path=".", **kwargs):
 

--- a/despasito/main.py
+++ b/despasito/main.py
@@ -21,7 +21,8 @@ class method_stat:
 
 logger = logging.getLogger(__name__)
 
-def commandline_parser():
+def get_parser():
+
     ## Define parser functions and arguments
     parser = argparse.ArgumentParser(description="DESPASITO: Determining Equilibrium State and Parametrization: Application for SAFT, Intended for Thermodynamic Output.  This is an open-source application for thermodynamic calculations and parameter fitting for the Statistical Associating Fluid Theory (SAFT) EOS and SAFT-𝛾-Mie coarse-grained simulations.")
     parser.add_argument("-i", "--input", dest="input", help="Input .json file with calculation instructions and path(s) to equation of state parameters. See documentation for explicit explanation. Compile docs or visit https://despasito.readthedocs.io")
@@ -33,12 +34,19 @@ def commandline_parser():
     parser.add_argument("--python", action='store_true', help="Remove default fortran module for association site calculations.")
     parser.add_argument("--cython", action='store_true', help="Turn on Cython for accelerated computation")
 
+    return parser
+
+def commandline_parser():
+    """ Dummy function that separates the parser definition (get_parser()) from the parsing (purpose: generating api.rst for sphinx-build)"""
+
+    parser = get_parser()
     args = parser.parse_args()
+
     method_stat.disable_numba = not args.numba
     method_stat.disable_cython = not args.cython
     method_stat.disable_python = not args.python
 
-    return args
+    return parser
 
 def run(filename="input.json", path=".", **kwargs):
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -9,7 +9,7 @@ See examples directory or Input/Output documentation for input file structures.
 Command Line
 ------------
 .. argparse::
-   :ref: despasito.main.commandline_parser
+   :ref: despasito.main.get_parser
    :prog: python -m despasito
 
 Imported Package


### PR DESCRIPTION
## Description
Separated implementation of **main/commandline_parser()** from its definition by introducing a new function **main/get_parser()**. Reason being sphinx-argparse expects the ref function to return an instance of the parser and not the parsed args.

## Status
- [x] Ready to go